### PR TITLE
Fixed instance seg dtype, allowed change of normalization quantile, added model checkpoint version control

### DIFF
--- a/src/nimbus_inference/utils.py
+++ b/src/nimbus_inference/utils.py
@@ -249,6 +249,7 @@ class MultiplexDataset():
             instance_mask = np.squeeze(io.imread(instance_path))
         else:
             instance_mask = instance_path
+        instance_mask = instance_mask.astype(np.uint64)
         return instance_mask
 
 
@@ -336,9 +337,9 @@ def test_time_aug(
 
 
 def predict_fovs(
-        nimbus, dataset: MultiplexDataset, normalization_dict: dict, output_dir: str,
-        suffix: str="tiff", save_predictions: bool=True, half_resolution: bool=False,
-        batch_size: int=4, test_time_augmentation: bool=True
+        nimbus, dataset: MultiplexDataset, normalization_dict: dict,
+        output_dir: str, suffix: str="tiff", save_predictions: bool=True,
+        half_resolution: bool=False, batch_size: int=4, test_time_augmentation: bool=True
     ):
     """Predicts the segmentation map for each mplex image in each fov
     Args:

--- a/templates/1_Nimbus_Predict.ipynb
+++ b/templates/1_Nimbus_Predict.ipynb
@@ -246,6 +246,7 @@
    "outputs": [],
    "source": [
     "nimbus.prepare_normalization_dict(\n",
+    "    quantile=0.999,\n",
     "    n_subset=50,\n",
     "    multiprocessing=True,\n",
     "    overwrite=True\n",

--- a/templates/1_Nimbus_Predict.ipynb
+++ b/templates/1_Nimbus_Predict.ipynb
@@ -248,6 +248,7 @@
     "nimbus.prepare_normalization_dict(\n",
     "    quantile=0.999,\n",
     "    n_subset=50,\n",
+    "    clip_values=(0, 2),\n",
     "    multiprocessing=True,\n",
     "    overwrite=True\n",
     ")"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,6 +24,7 @@ class MockModel(torch.nn.Module):
 
 def prepare_tif_data(
         num_samples, temp_dir, selected_markers, random=False, std=1, shape=(256, 256),
+        image_dtype=np.float32, instance_dtype=np.uint16
     ):
     np.random.seed(42)
     fov_paths = []
@@ -42,13 +43,13 @@ def prepare_tif_data(
                 img = np.ones(shape)
             io.imsave(
                 os.path.join(folder, marker + ".tiff"),
-                img,
+                img.astype(image_dtype),
             )
         inst_path = os.path.join(deepcell_dir, f"fov_{i}_whole_cell.tiff")
         io.imsave(
                 inst_path, np.array(
                     [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]
-                ).repeat(shape[1]//4, axis=1).repeat(shape[0]//4, axis=0)
+                ).repeat(shape[1]//4, axis=1).repeat(shape[0]//4, axis=0).astype(instance_dtype)
         )
         if folder not in fov_paths:
             fov_paths.append(folder)
@@ -255,7 +256,8 @@ def test_predict_fovs():
             return os.path.join(temp_dir_, "deepcell_output", fov_ + "_whole_cell.tiff")
 
         fov_paths, _ = prepare_tif_data(
-            num_samples=1, temp_dir=temp_dir, selected_markers=["CD4", "CD56"], shape=(512, 256)
+            num_samples=1, temp_dir=temp_dir, selected_markers=["CD4", "CD56"], shape=(512, 256),
+            instance_dtype=np.float32
         )
         dataset = MultiplexDataset(fov_paths, segmentation_naming_convention, suffix=".tiff")
         output_dir = os.path.join(temp_dir, "nimbus_output")


### PR DESCRIPTION
**What is the purpose of this PR?**

1. Add support for float instance segmentation maps as requested in #18 
2. Add functionality to change normalization quantile and clip marker expression after normalization to fix #17 
3. Add functionality to automatically update model weights when we upload new checkpoints to the huggingface hub.

**How did you implement your changes**

1. Cast all instance segmentation maps to uint64 prior to further analysis. 
2. Added normalization quantile and clipping to the interface of `Nimbus.prepare_normalization_dict`
3. Changed `Nimbus.initialize_model` to first check if there exists a checkpoint with a higher version tag ('V1.pt', 'V2.pt',...) on the huggingface hub. Then download the checkpoint and load the weights into the model.

**Remaining issues**

None.