### PR TITLE
Added handling of qupath segmap and huggingface timeouts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ doc = [
     "sphinx-copybutton",
     "pandas",
 ]
-test = ["pytest", "coverage", "coveralls[toml]", "pytest-cov"]
+test = ["pytest", "coverage", "coveralls[toml]", "pytest-cov", "pytest-socket"]
 
 [tool.coverage.run]
 source = ["nimbus_inference"]

--- a/src/nimbus_inference/nimbus.py
+++ b/src/nimbus_inference/nimbus.py
@@ -137,19 +137,20 @@ class Nimbus(nn.Module):
         path = Path(path).resolve()
         local_dir = os.path.join(path, "assets")
         os.makedirs(local_dir, exist_ok=True)
+        version_pattern = re.compile(r'V(\d+)\.pt')
+        local_checkpoints = [f for f in os.listdir(local_dir) if version_pattern.search(f)]
+
         try: # download model weights from Hugging Face Hub and revert to local checkpoint if
             # download fails
             repo_id = "JLrumberger/Nimbus-Inference"
             file_list = list_repo_files(repo_id)
             # Find the latest version on Hugging Face Hub
-            version_pattern = re.compile(r'V(\d+)\.pt')
             versions = [int(version_pattern.search(file).group(1)) for file in file_list if version_pattern.search(file)]
             if not versions:
                 raise ValueError("No valid model checkpoints found on Hugging Face Hub.")
             latest_hub_version = max(versions)
             latest_hub_checkpoint = f"V{latest_hub_version}.pt"
             # Check local version
-            local_checkpoints = [f for f in os.listdir(local_dir) if version_pattern.search(f)]
             if local_checkpoints:
                 local_versions = [int(version_pattern.search(file).group(1)) for file in local_checkpoints]
                 latest_local_version = max(local_versions)
@@ -170,15 +171,20 @@ class Nimbus(nn.Module):
                 print(f"Downloaded weights to {self.checkpoint_path}")
             else:
                 print(f"Using existing checkpoint: {self.checkpoint_path}")
-        except Exception as e:
-            local_versions = [
-                int(version_pattern.search(file).group(1)) for file in local_checkpoints
-            ]
-            latest_local_version = max(local_versions)
-            latest_local_checkpoint = f"V{latest_local_version}.pt"
-            self.checkpoint_path = os.path.join(local_dir, latest_local_checkpoint)
-            print(f"Failed to download model weights from Hugging Face Hub: {e}")
-            print(f"Using existing checkpoint: {self.checkpoint_path}")
+        except:
+            if local_checkpoints:
+                local_versions = [
+                    int(version_pattern.search(file).group(1)) for file in local_checkpoints
+                ]
+                latest_local_version = max(local_versions)
+                latest_local_checkpoint = f"V{latest_local_version}.pt"
+                self.checkpoint_path = os.path.join(local_dir, latest_local_checkpoint)
+                print(f"Failed to download model weights from Hugging Face Hub")
+                print(f"Using existing checkpoint: {self.checkpoint_path}")
+            else:
+                raise ValueError(
+                    "No connection to HuggingFace Hub and no local model checkpoints found."
+                )
         # Load the model
         model = UNet(num_classes=1, padding=padding)
         model.load_state_dict(torch.load(self.checkpoint_path))

--- a/src/nimbus_inference/nimbus.py
+++ b/src/nimbus_inference/nimbus.py
@@ -137,37 +137,47 @@ class Nimbus(nn.Module):
         path = Path(path).resolve()
         local_dir = os.path.join(path, "assets")
         os.makedirs(local_dir, exist_ok=True)
-        # Get list of model files from Hugging Face Hub
-        repo_id = "JLrumberger/Nimbus-Inference"
-        file_list = list_repo_files(repo_id)
-        # Find the latest version on Hugging Face Hub
-        version_pattern = re.compile(r'V(\d+)\.pt')
-        versions = [int(version_pattern.search(file).group(1)) for file in file_list if version_pattern.search(file)]
-        if not versions:
-            raise ValueError("No valid model checkpoints found on Hugging Face Hub.")
-        latest_hub_version = max(versions)
-        latest_hub_checkpoint = f"V{latest_hub_version}.pt"
-        # Check local version
-        local_checkpoints = [f for f in os.listdir(local_dir) if version_pattern.search(f)]
-        if local_checkpoints:
-            local_versions = [int(version_pattern.search(file).group(1)) for file in local_checkpoints]
+        try: # download model weights from Hugging Face Hub and revert to local checkpoint if
+            # download fails
+            repo_id = "JLrumberger/Nimbus-Inference"
+            file_list = list_repo_files(repo_id)
+            # Find the latest version on Hugging Face Hub
+            version_pattern = re.compile(r'V(\d+)\.pt')
+            versions = [int(version_pattern.search(file).group(1)) for file in file_list if version_pattern.search(file)]
+            if not versions:
+                raise ValueError("No valid model checkpoints found on Hugging Face Hub.")
+            latest_hub_version = max(versions)
+            latest_hub_checkpoint = f"V{latest_hub_version}.pt"
+            # Check local version
+            local_checkpoints = [f for f in os.listdir(local_dir) if version_pattern.search(f)]
+            if local_checkpoints:
+                local_versions = [int(version_pattern.search(file).group(1)) for file in local_checkpoints]
+                latest_local_version = max(local_versions)
+                latest_local_checkpoint = f"V{latest_local_version}.pt"
+                self.checkpoint_path = os.path.join(local_dir, latest_local_checkpoint)
+            else:
+                latest_local_version = 0
+            # Compare versions and download if necessary
+            if latest_hub_version > latest_local_version:
+                print(f"Newer model checkpoint found: {latest_hub_checkpoint}")
+                print("Downloading from Hugging Face Hub...")
+                self.checkpoint_path = hf_hub_download(
+                    repo_id=repo_id,
+                    filename=latest_hub_checkpoint,
+                    local_dir=local_dir,
+                    local_dir_use_symlinks=False,
+                )
+                print(f"Downloaded weights to {self.checkpoint_path}")
+            else:
+                print(f"Using existing checkpoint: {self.checkpoint_path}")
+        except Exception as e:
+            local_versions = [
+                int(version_pattern.search(file).group(1)) for file in local_checkpoints
+            ]
             latest_local_version = max(local_versions)
             latest_local_checkpoint = f"V{latest_local_version}.pt"
             self.checkpoint_path = os.path.join(local_dir, latest_local_checkpoint)
-        else:
-            latest_local_version = 0
-        # Compare versions and download if necessary
-        if latest_hub_version > latest_local_version:
-            print(f"Newer model checkpoint found: {latest_hub_checkpoint}")
-            print("Downloading from Hugging Face Hub...")
-            self.checkpoint_path = hf_hub_download(
-                repo_id=repo_id,
-                filename=latest_hub_checkpoint,
-                local_dir=local_dir,
-                local_dir_use_symlinks=False,
-            )
-            print(f"Downloaded weights to {self.checkpoint_path}")
-        else:
+            print(f"Failed to download model weights from Hugging Face Hub: {e}")
             print(f"Using existing checkpoint: {self.checkpoint_path}")
         # Load the model
         model = UNet(num_classes=1, padding=padding)

--- a/src/nimbus_inference/nimbus.py
+++ b/src/nimbus_inference/nimbus.py
@@ -145,6 +145,7 @@ class Nimbus(nn.Module):
             repo_id = "JLrumberger/Nimbus-Inference"
             file_list = list_repo_files(repo_id)
             # Find the latest version on Hugging Face Hub
+            print("Checking for updated model checkpoints on HuggingFace Hub...")
             versions = [int(version_pattern.search(file).group(1)) for file in file_list if version_pattern.search(file)]
             if not versions:
                 raise ValueError("No valid model checkpoints found on Hugging Face Hub.")

--- a/src/nimbus_inference/utils.py
+++ b/src/nimbus_inference/utils.py
@@ -109,7 +109,7 @@ class LazyOMETIFFReader(OMETIFFReader):
         return channel
 
 
-def handle_qupath_segmentation_map(instance_mask):
+def handle_qupath_segmentation_map(instance_mask: np.array):
     """Handle QuPath segmentation maps stored as 24-bit RGB images
     Args:
         instance_mask (np.array): instance mask
@@ -120,9 +120,9 @@ def handle_qupath_segmentation_map(instance_mask):
     logging.warning("QuPath RGB segmentation map detected. Converting to instance map by")
     logging.warning("combining the RGB channels into a single channel via the following formula:")
     logging.warning("label = RED*256**2 + GREEN * 256 + BLUE")
-    instance_mask = instance_mask[..., 0] * 256**2 + instance_mask[..., 1] * 256 \
+    instance_mask_handled = instance_mask[..., 0] * 256**2 + instance_mask[..., 1] * 256 \
         + instance_mask[..., 2]
-    instance_mask = instance_mask.round(0).astype(np.uint64)
+    instance_mask_handled = instance_mask_handled.round(0).astype(np.uint64)
     return instance_mask
 
 

--- a/src/nimbus_inference/utils.py
+++ b/src/nimbus_inference/utils.py
@@ -268,7 +268,7 @@ class MultiplexDataset():
             instance_mask = np.squeeze(instance_path)
         if len(instance_mask.shape) == 3 and instance_mask.shape[-1] == 3:
             instance_mask = handle_qupath_segmentation_map(instance_mask)
-        instance_mask = instance_mask.astype(np.uint64)
+        instance_mask = instance_mask.astype(np.uint32)
         return instance_mask
 
 

--- a/src/nimbus_inference/utils.py
+++ b/src/nimbus_inference/utils.py
@@ -123,7 +123,7 @@ def handle_qupath_segmentation_map(instance_mask: np.array):
     instance_mask_handled = instance_mask[..., 0] * 256**2 + instance_mask[..., 1] * 256 \
         + instance_mask[..., 2]
     instance_mask_handled = instance_mask_handled.round(0).astype(np.uint64)
-    return instance_mask
+    return instance_mask_handled
 
 
 class MultiplexDataset():

--- a/src/nimbus_inference/utils.py
+++ b/src/nimbus_inference/utils.py
@@ -109,6 +109,23 @@ class LazyOMETIFFReader(OMETIFFReader):
         return channel
 
 
+def handle_qupath_segmentation_map(instance_mask):
+    """Handle QuPath segmentation maps stored as 24-bit RGB images
+    Args:
+        instance_mask (np.array): instance mask
+    Returns:
+        instance_mask (np.array): instance mask
+    """
+    # add warning
+    logging.warning("QuPath RGB segmentation map detected. Converting to instance map by")
+    logging.warning("combining the RGB channels into a single channel via the following formula:")
+    logging.warning("label = RED*256**2 + GREEN * 256 + BLUE")
+    instance_mask = instance_mask[..., 0] * 256**2 + instance_mask[..., 1] * 256 \
+        + instance_mask[..., 2]
+    instance_mask = instance_mask.round(0).astype(np.uint64)
+    return instance_mask
+
+
 class MultiplexDataset():
     def __init__(
             self, fov_paths: list, segmentation_naming_convention: Callable = None,
@@ -248,7 +265,9 @@ class MultiplexDataset():
         if isinstance(instance_path, str):
             instance_mask = np.squeeze(io.imread(instance_path))
         else:
-            instance_mask = instance_path
+            instance_mask = np.squeeze(instance_path)
+        if len(instance_mask.shape) == 3 and instance_mask.shape[-1] == 3:
+            instance_mask = handle_qupath_segmentation_map(instance_mask)
         instance_mask = instance_mask.astype(np.uint64)
         return instance_mask
 

--- a/tests/test_nimbus.py
+++ b/tests/test_nimbus.py
@@ -1,4 +1,6 @@
 from tests.test_utils import prepare_ome_tif_data, prepare_tif_data
+from pytest_socket import disable_socket, enable_socket
+import pytest
 import tempfile
 from nimbus_inference.utils import MultiplexDataset
 from nimbus_inference.nimbus import Nimbus, prep_naming_convention
@@ -33,6 +35,11 @@ def test_initialize_model():
     nimbus.initialize_model(padding="reflect")
     assert isinstance(nimbus.model, UNet)
     assert nimbus.model.padding == "reflect"
+    # test if model gets loaded in offline mode when it was loaded from huggingface hub before
+    nimbus.model = None
+    disable_socket()
+    nimbus.initialize_model(padding="valid")
+    assert isinstance(nimbus.model, UNet)
 
 
 def test_prepare_normalization_dict():


### PR DESCRIPTION
**What is the purpose of this PR?**

1. Handling qupath saved RGB segmentation maps by converting them back to single-channel label images with the following formula `label = RED * 256 * 256 + GREEN * 256 + BLUE` to decrease friction for users according to #18 .
2. Always checking local and huggingface model versions requires internet access whenever one wants to run nimbus inference. This is not a good design I think, thus I added some exception handling workflow so that you can run nimbus without internet access if a local checkpoint is available.

**How did you implement your changes**

1. Added function `handle_qupath_segmentation_map` to utils that converts RGB segmentation maps to single channel ones, this function only gets called in the Dataset class `if len(instance_mask.shape) == 3 and instance_mask.shape[-1] == 3`.
2. Added a try / except clause to the huggingface version lookup routine in the Nimbus class.

**Remaining issues**

None