### PR TITLE
Fixed uint16 inference bug

### DIFF
--- a/src/nimbus_inference/utils.py
+++ b/src/nimbus_inference/utils.py
@@ -298,6 +298,7 @@ class MultiplexDataset():
             print("No normalization dict found. Preparing normalization dict...")
             self.prepare_normalization_dict()
         mplex_img = self.get_channel(fov, channel)
+        mplex_img = mplex_img.astype(np.float32)
         if channel in self.normalization_dict.keys():
             norm_factor = self.normalization_dict[channel]
         else:


### PR DESCRIPTION
**What is the purpose of this PR?**

This PR adresses #32 and fixes a bug in the inference pipeline that happened when images where saved in uint16 format.

**How did you implement your changes**

I added a typecast and tests for uint16 and float32 images.

**Remaining issues**

None.